### PR TITLE
Fixed frame rate not being set

### DIFF
--- a/MWCamera/Classes/MWBaseCameraViewController.swift
+++ b/MWCamera/Classes/MWBaseCameraViewController.swift
@@ -196,7 +196,10 @@ extension MWBaseCameraViewController {
         }
 
         guard videoDevice.activeVideoMinFrameDuration.timescale != frameRate,
-            videoDevice.activeVideoMaxFrameDuration.timescale != frameRate else { return }
+            videoDevice.activeVideoMaxFrameDuration.timescale != frameRate else {
+                self.frameRate = frameRate
+                return
+        }
 
         do {
             try videoDevice.lockForConfiguration()


### PR DESCRIPTION
If the desired frame rate is the same as the videoDevice's frame rate the frameRate variable is not being set causing the frame correction logic in `handleVideoBuffer` not function properly